### PR TITLE
Invoke w/ no prefix in channel with correct topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voice Count (Discord bot)
 
-Go to: **[Usage]**, **[Setup]**, **[License]**
+Jump to: **[Usage]**, **[Setup]**, **[License]**
 
 [Usage]: #usage
 [Setup]: #setup
@@ -43,13 +43,14 @@ If you need to stop the bot, run this command (owner only).
 count::kill
 ```
 
-If `count::` is too cumbersome, you can omit the prefix if the channel is named
-`#bot` or `#count-bot`. Alternatively, you can mention the bot - useful on
-mobile.
+### Advanced
+
+If `count::` is too cumbersome, you can mention the bot. Alternatively, you can omit the
+prefix entirely if the channel topic at-mentions the bot.
 
 ## Setup
 
-You'll need Git, Python, and **[Poetry]** to run this bot. Some level of
+You'll need Git, Python (minimum is 3.6), and **[Poetry]** to run this bot. Some level of
 technical knowledge is expected. If you care enough to write a better tutorial,
 send a PR!
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,24 @@ If you need to stop the bot, run this command (owner only).
 count::kill
 ```
 
+<img width="500px" align="right" alt="Watch & discuss movies. Use &lt;@593717174732980224&gt; to count down. Commands: 'help'" src="https://user-images.githubusercontent.com/52195359/87511345-7fe1ad80-c6b8-11ea-87ba-1a5aac608f19.png">
+
 ### Advanced
 
-If `count::` is too cumbersome, you can mention the bot. Alternatively, you can omit the
-prefix entirely if the channel topic at-mentions the bot.
+If `count::` is too cumbersome, you can mention the bot instead of using it.
+Alternatively, you can omit the prefix entirely if the channel topic mentions
+the bot.
+
+See an example channel topic on the right. ➟<br>
+<sub>[Read more on formatting][format].</sub>
+
+[format]: https://discord.com/developers/docs/reference#message-formatting-formats
 
 ## Setup
 
-You'll need Git, Python (minimum is 3.6), and **[Poetry]** to run this bot. Some level of
-technical knowledge is expected. If you care enough to write a better tutorial,
-send a PR!
+You'll need Git, Python (minimum is 3.6), and **[Poetry]** to run this bot.
+Some level of technical knowledge is expected. If you care enough to write a
+better tutorial, send a PR!
 
 [Poetry]: https://python-poetry.org/docs/#installation
 

--- a/count.py
+++ b/count.py
@@ -21,9 +21,10 @@ def prefix(bot: commands.Bot, msg: discord.Message) -> List[str]:
     prefixes.append("count::")
 
     # DMChannel has no `name` property.
-    name = getattr(msg.channel, "name", "")
+    mention = bot.user.mention
+    topic = getattr(msg.channel, "topic", mention)
 
-    if name in {"bot", "count-bot", "the-count"} or not name:
+    if mention in topic:
         prefixes.append("")
 
     return prefixes

--- a/count.py
+++ b/count.py
@@ -40,7 +40,7 @@ async def on_ready():
     logging.info(f"Owner ID: {client.owner_id}")
 
 
-@bot.event
+@client.event
 async def on_command_error(ctx: commands.Context, error: commands.CommandError):
     """Ignore `CommandNotFound` if the command prefix is omitted."""
     # The prefix can only be omitted in specific channels, this is fine.

--- a/count.py
+++ b/count.py
@@ -17,14 +17,12 @@ assets = Path(__file__).parent / "assets"
 
 def prefix(bot: commands.Bot, msg: discord.Message) -> List[str]:
     """Invoke with `count::`, a mention, or nothing if the topic mentions the bot."""
-    prefixes = commands.when_mentioned(bot, msg)
-    prefixes.append("count::")
+    prefixes = ["count::"]
+    prefixes += commands.when_mentioned(bot, msg)
 
-    # DMChannel has no `name` property.
     mention = bot.user.mention
     topic = getattr(msg.channel, "topic", mention)
-
-    if mention in topic:
+    if topic is not None and mention in topic:
         prefixes.append("")
 
     return prefixes

--- a/count.py
+++ b/count.py
@@ -16,7 +16,7 @@ assets = Path(__file__).parent / "assets"
 
 
 def prefix(bot: commands.Bot, msg: discord.Message) -> List[str]:
-    """Invoke with `count::`, a mention, or no prefix in `#bot` or `#count-bot`."""
+    """Invoke with `count::`, a mention, or nothing if the topic mentions the bot."""
     prefixes = commands.when_mentioned(bot, msg)
     prefixes.append("count::")
 
@@ -36,8 +36,8 @@ client = commands.Bot(command_prefix=prefix)
 @client.event
 async def on_ready():
     logging.info(f"Bot is ready: {client.user}")
-    logging.info(f"Bot ID: {client.user.id}")
-    logging.info(f"Owner ID: {client.owner_id}")
+    logging.info(f"Bot ID: . . . {client.user.id}")
+    logging.info(f"Owner ID: . . {client.owner_id}")
 
 
 @client.event

--- a/count.py
+++ b/count.py
@@ -40,6 +40,15 @@ async def on_ready():
     logging.info(f"Owner ID: {client.owner_id}")
 
 
+@bot.event
+async def on_command_error(ctx: commands.Context, error: commands.CommandError):
+    """Ignore `CommandNotFound` if the command prefix is omitted."""
+    # The prefix can only be omitted in specific channels, this is fine.
+    if isinstance(error, commands.CommandNotFound) and not ctx.prefix:
+        return
+    raise error
+
+
 @client.before_invoke
 async def log_command_usage(ctx: commands.Context):
     """Log each command used, along with the author and timestamp."""


### PR DESCRIPTION
The bot will only accept no-prefix invocation in a channel that mentions the bot in the topic.

For example, set the topic to `Use <@YOUR_BOT_ID> here.`